### PR TITLE
remove start

### DIFF
--- a/lib/mailcrate.rb
+++ b/lib/mailcrate.rb
@@ -8,16 +8,14 @@ class Mailcrate
 
   attr_reader :mails, :port
 
-  def initialize(port)
+  def initialize(port, options={})
+    raise Errno::EADDRINUSE if self.class.used_ports.include?(port)
+
+    self.class.used_ports << port
+    @service = options[:service] || TCPServer.new('localhost', port)
+    @thread = Thread.new { accept(@service) }
     @port = port
     @mails = []
-  end
-
-  def start(opts = {})
-    raise Errno::EADDRINUSE if self.class.used_ports.include?(@port)
-    self.class.used_ports << @port
-    @service = opts[:service] || TCPServer.new('localhost', @port)
-    @thread = Thread.new { accept(@service) }
   end
 
   def stop

--- a/spec/mailcrate_spec.rb
+++ b/spec/mailcrate_spec.rb
@@ -12,49 +12,46 @@ describe Mailcrate do
 
   describe 'ports' do
     it 'opens a port' do
-      mailcrate.start
-
       expect(port(TEST_PORT)).to be_open
     end
 
     it 'can read the port' do
-      mailcrate.start # makes .stop not blow up
-
       expect(mailcrate.port).to eq TEST_PORT
     end
 
     it 'closes a port' do
-      mailcrate.start
       mailcrate.stop
 
       expect(port(TEST_PORT)).to_not be_open
     end
 
     it 'does not allow a second server to be started on the same port' do
-      mailcrate.start
       expect {
-        Mailcrate.new(TEST_PORT).start
+        Mailcrate.new(TEST_PORT)
       }.to raise_error(Errno::EADDRINUSE)
     end
   end
 
   describe 'starting and stopping' do
     it 'should block when start is called until SMTP server is ready' do
-      slow_server = SlowTCPServer.new('localhost', TEST_PORT)
+      mailcrate.stop
 
-      mailcrate.start(:service => slow_server)
+      begin
+        slow_server = SlowTCPServer.new('localhost', TEST_PORT)
+        mailcrate = Mailcrate.new(TEST_PORT, :service => slow_server)
 
-      socket = TCPSocket.open('localhost', TEST_PORT)
-      welcome_message = socket.gets.chomp
+        socket = TCPSocket.open('localhost', TEST_PORT)
+        welcome_message = socket.gets.chomp
 
-      expect(welcome_message).to eq '220 localhost mailcrate ready ESTMP'
+        expect(welcome_message).to eq '220 localhost mailcrate ready ESTMP'
+      ensure
+        mailcrate.stop
+      end
     end
   end
 
   describe 'should accept SMTP traffic' do
     it 'should recieve email' do
-      mailcrate.start
-
       socket = TCPSocket.open('localhost', TEST_PORT)
       socket.puts('helo localhost.localdomain')
       socket.puts('MAIL FROM:myaddress@mydomain.com')


### PR DESCRIPTION
@adscott 

calling new returns a broken object, that then has to be 'initialized' by calling start ...
how about just starting the server -> object is always in a valid state + 1 less step
